### PR TITLE
Update which-key comma descriptions

### DIFF
--- a/lua/niia/plugins/which_key.lua
+++ b/lua/niia/plugins/which_key.lua
@@ -66,13 +66,13 @@ return {
                     "<m-,>",
                     "<esc>mzA,<esc>`z",
                     mode = "n",
-                    desc = "Insert ; at end of line",
+                    desc = "Insert , at end of line",
                 },
                 {
                     "<m-,>",
                     "<esc>mzA,<esc>`za",
                     mode = "i",
-                    desc = "Insert ; at end of line",
+                    desc = "Insert , at end of line",
                 },
                 {
                     "<c-l>",


### PR DESCRIPTION
## Summary
- correct the which-key tooltip descriptions for the <m-,> mapping in normal and insert modes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc13c93e2883228af0c6d08975cbee