### PR TITLE
Fix rust-analyzer procedural macro setting

### DIFF
--- a/lua/niia/plugins/lsp/servers/rust_analyzer.lua
+++ b/lua/niia/plugins/lsp/servers/rust_analyzer.lua
@@ -12,7 +12,7 @@ return {
                     enable = true,
                 },
             },
-            proMacro = {
+            procMacro = {
                 enable = true,
             },
         },


### PR DESCRIPTION
## Summary
- rename the rust-analyzer configuration key to `procMacro` so procedural macros remain enabled

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc13cb7f808322933d528a81219d00